### PR TITLE
fix(util): `now()` causing runtime exception on Chrome

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@
 export let now: () => number
 try {
   if (typeof window !== 'undefined') {
-    now = performance.now
+    now = () => performance.now()
   } else {
     const { performance } = require('perf_hooks')
     now = performance.now


### PR DESCRIPTION
When trying to execute macao on Chrome, I was getting a `Type error: Illegal invocation` traced to the execution of `now()`.

I looked briefly on the web for info and found this which gave me the idea for the fix:
   https://coderedirect.com/questions/116205/uncaught-typeerror-illegal-invocation-in-javascript

Using an eta-expension and thus making the call in the context of `performance` seems to fix the issue for me.

I am not claiming this is a complete fix, adding there for your consideration. Please adapt as desired. Thanks!